### PR TITLE
quickwiki module

### DIFF
--- a/GWToolbox/GWToolbox.vcxproj
+++ b/GWToolbox/GWToolbox.vcxproj
@@ -123,6 +123,7 @@
     <ClInclude Include="GWToolbox\Modules\ChatCommands.h" />
     <ClInclude Include="GWToolbox\Modules\ChatFilter.h" />
     <ClInclude Include="GWToolbox\Modules\DiscordModule.h" />
+    <ClInclude Include="GWToolbox\Modules\QuickWikiModule.h" />
     <ClInclude Include="GWToolbox\Modules\ZrawDeepModule.h" />
     <ClInclude Include="GWToolbox\Modules\PartyWindowModule.h" />
     <ClInclude Include="GWToolbox\Modules\TwitchModule.h" />
@@ -232,6 +233,7 @@
     <ClCompile Include="GWToolbox\Modules\ChatCommands.cpp" />
     <ClCompile Include="GWToolbox\Modules\ChatFilter.cpp" />
     <ClCompile Include="GWToolbox\Modules\DiscordModule.cpp" />
+    <ClCompile Include="GWToolbox\Modules\QuickWikiModule.cpp" />
     <ClCompile Include="GWToolbox\Modules\ZrawDeepModule.cpp" />
     <ClCompile Include="GWToolbox\Modules\PartyWindowModule.cpp" />
     <ClCompile Include="GWToolbox\Modules\TwitchModule.cpp" />

--- a/GWToolbox/GWToolbox.vcxproj.filters
+++ b/GWToolbox/GWToolbox.vcxproj.filters
@@ -300,6 +300,7 @@
     <ClInclude Include="GWToolbox\Modules\ZrawDeepModule.h" />
     <ClInclude Include="GWToolbox\Widgets\Minimap\EffectRenderer.h" />
     <ClInclude Include="GWToolbox\Windows\TradeWindowExtended.h" />
+    <ClInclude Include="GWToolbox\Modules\QuickWikiModule.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="GWToolbox\main.cpp" />
@@ -465,6 +466,7 @@
     <ClCompile Include="GWToolbox\Modules\ZrawDeepModule.cpp" />
     <ClCompile Include="GWToolbox\Widgets\Minimap\EffectRenderer.cpp" />
     <ClCompile Include="GWToolbox\Windows\TradeWindowExtended.cpp" />
+    <ClCompile Include="GWToolbox\Modules\QuickWikiModule.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="GWToolbox.rc">

--- a/GWToolbox/GWToolbox/Modules/GameSettings.cpp
+++ b/GWToolbox/GWToolbox/Modules/GameSettings.cpp
@@ -41,6 +41,9 @@
 #include <Color.h>
 #include <Windows\StringDecoderWindow.h>
 
+#include <Modules/Resources.h>
+#include <regex>
+
 namespace {
 	void SendChatCallback(GW::HookStatus *, GW::Chat::Channel chan, wchar_t msg[120]) {
 		if (!GameSettings::Instance().auto_url || !msg) return;
@@ -1749,9 +1752,84 @@ bool GameSettings::WndProc(UINT Message, WPARAM wParam, LPARAM lParam) {
 	return false;
 }
 
+static void ExtractCraftingFromWiki(std::string wiki_page, std::string regex_str) {
+	std::cout << regex_str << std::endl;
+
+	std::smatch sm1;
+	std::regex regex_check1(regex_str);
+
+	// grab the right <td></td>
+	std::regex_search(wiki_page, sm1, regex_check1);
+
+	std::cout << "sm1.length: " << sm1.size() << std::endl;
+
+	for (auto m : sm1) {
+		std::cout << '[' << m << ']' << std::endl;
+	}
+
+	if (sm1.size() == 2) {
+		// TODO: replace <br /> with newline
+
+		// strip all tags
+		std::regex regex_tags("<[^>]*>");
+		std::string final = std::regex_replace(sm1.str(1), regex_tags, "");// "!");
+
+		std::cout << final << std::endl;
+		
+		GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, final.c_str());
+	}
+}
+
+static void ParseWiki(std::string wiki_page) {
+	std::cout << "wiki_page.length: " << wiki_page.length() << std::endl;
+	wiki_page.erase(std::remove(wiki_page.begin(), wiki_page.end(), '\n'), wiki_page.end());
+	wiki_page.erase(std::remove(wiki_page.begin(), wiki_page.end(), '\r'), wiki_page.end());
+	wiki_page.erase(std::remove(wiki_page.begin(), wiki_page.end(), '\t'), wiki_page.end());
+
+	std::cout << wiki_page << std::endl;
+
+	std::cout << "wiki_page.length: " << wiki_page.length() << std::endl;
+
+	GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, "Common_crafting_material");
+	ExtractCraftingFromWiki(wiki_page, "Common_crafting_material.*?<td>(.*?)</td>");
+
+	GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, "Rare_crafting_material");
+	ExtractCraftingFromWiki(wiki_page, "Rare_crafting_material.*?<td>(.*?)</td>");
+}
+
+static void WikiSalvageCallback(std::string html) {
+
+	//std::string test_str = "asdasd a dADS  \n3 r234wr atr 34ta34 <tr valign=\"top\">\n<th style=\"background-color:#FA5;\"> <span\nstyle=\"white-space:nowrap;\"><a href=\"/wiki/Common_crafting_material\" title=\"Common crafting material\">Common salvage</a></span></th><td> <a href=\"/wiki/Pile_of_Glittering_Dust\" title=\"Pile of Glittering Dust\">Pile of Glittering Dust</a></td></tr><tr valign=\"top\">\n<th style=\"background-color:#FA5;\"> <span\nstyle=\"white-space:nowrap;\"><a href=\"/wiki/Common_crafting_material\" title=\"Common crafting material\">Common salvage</a></span></th><td> <a href=\"/wiki/Pile_of_Glittering_Dust\" title=\"Pile of Glittering Dust\">Pile of Glittering Dust</a></td></tr>";
+	//std::string test_str2 = "<table align=\"right\" style=\"margin:0 0 0.5em 1em; border:1px solid silver; font-size:90%; text-align:left; background-color:white;\" cellpadding=\"5\" cellspacing=\"3\"><tr><th colspan=\"2\" style=\"font-size:110%; text-align:center; background-color:#FA5;\"> Pronged Fan</th></tr><tr><td colspan=\"2\" align=\"center\"> <a href=\"/wiki/File:Pronged_Fan.jpg\" class=\"image\"><img alt=\"Pronged Fan.jpg\" src=\"/images/e/e8/Pronged_Fan.jpg\" width=\"250\" height=\"379\" /></a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <a href=\"/wiki/Weapon#Weapon_types\" title=\"Weapon\">Type</a></th><td> <a href=\"/wiki/Focus_item\" title=\"Focus item\">Focus item</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <a href=\"/wiki/Campaign\" title=\"Campaign\">Campaign(s)</a></th><td> <a href=\"/wiki/Factions\" class=\"mw-redirect\" title=\"Factions\">Factions</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <a href=\"/wiki/Attribute\" title=\"Attribute\">Attribute</a><br /><a href=\"/wiki/Requirement\" title=\"Requirement\">requirement(s)</a></th><td> <a href=\"/wiki/Divine_Favor\" title=\"Divine Favor\">Divine Favor</a><br /><a href=\"/wiki/Energy_Storage\" title=\"Energy Storage\">Energy Storage</a><br /><a href=\"/wiki/Inspiration_Magic\" title=\"Inspiration Magic\">Inspiration Magic</a><br /><a href=\"/wiki/Soul_Reaping\" title=\"Soul Reaping\">Soul Reaping</a><br /><a href=\"/wiki/Spawning_Power\" title=\"Spawning Power\">Spawning Power</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/PvP_reward\" title=\"PvP reward\">PvP reward class</a></span></th><td> Exotic<br />5 <span style=\"position:relative;top:-1.5px\"><a href=\"/wiki/File:Gold_Zaishen_Coin.png\" class=\"image\" title=\"Gold Zaishen Coin\"><img alt=\"Gold Zaishen Coin\" src=\"/images/thumb/2/26/Gold_Zaishen_Coin.png/19px-Gold_Zaishen_Coin.png\" width=\"19\" height=\"19\" srcset=\"/images/thumb/2/26/Gold_Zaishen_Coin.png/29px-Gold_Zaishen_Coin.png 1.5x, /images/thumb/2/26/Gold_Zaishen_Coin.png/38px-Gold_Zaishen_Coin.png 2x\" /></a></span></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/Common_crafting_material\" title=\"Common crafting material\">Common salvage</a></span></th><td> <a href=\"/wiki/Pile_of_Glittering_Dust\" title=\"Pile of Glittering Dust\">Pile of Glittering Dust</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/Rare_crafting_material\" title=\"Rare crafting material\">Rare salvage</a></span></th><td> ~9 <a href=\"/wiki/Roll_of_Parchment\" title=\"Roll of Parchment\">Rolls of Parchment</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/Inventory\" title=\"Inventory\">Inventory icon</a></span></th><td> <a href=\"/wiki/File:Pronged_Fan.png\" class=\"image\"><img alt=\"Pronged Fan.png\" src=\"/images/7/79/Pronged_Fan.png\" width=\"64\" height=\"64\" /></a></td></tr></table><table style=\"margin: 0.5em; border: 1px solid silver;\" cellpadding=\"5\" cellspacing=\"2\"><tr><td style=\"border:1px solid #aaa;\"> <a href=\"/wiki/File:Pronged_Fan_dye_chart.jpg\" class=\"image\"><img alt=\"Pronged Fan dye chart.jpg\" src=\"/images/thumb/9/97/Pronged_Fan_dye_chart.jpg/500px-Pronged_Fan_dye_chart.jpg\" width=\"500\" height=\"339\" srcset=\"/images/thumb/9/97/Pronged_Fan_dye_chart.jpg/750px-Pronged_Fan_dye_chart.jpg 1.5x, /images/9/97/Pronged_Fan_dye_chart.jpg 2x\" /></a></td></tr></table>";
+	//ParseWiki(test_str);
+	//ParseWiki(test_str2);
+	ParseWiki(html);
+
+
+}
+
+static void WikiSalvageCheck(GW::Item *item) {
+	std::wstring decoded;
+	std::wstring wiki_url(L"https://wiki.guildwars.com/wiki/");
+
+	GW::UI::AsyncDecodeStr(item->name_enc, &decoded);
+
+	std::wstring item_url = std::regex_replace(decoded, std::wregex(L" "), std::wstring(L"_"));
+	std::wstring final_url = wiki_url + item_url;
+	std::wstring chat_url = std::wstring(L"<a=1>") + final_url + std::wstring(L"</a>");
+	
+	printf("<%ls>\n", decoded.c_str());
+	printf("<%ls>\n", item_url.c_str());
+	printf("<%ls>\n", chat_url.c_str());
+
+	GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, chat_url.c_str());
+	//Resources::Instance().Download(L"https://wiki.guildwars.com/wiki/Pronged_Fan", WikiSalvageCallback);
+	Resources::Instance().Download(final_url, WikiSalvageCallback);
+}
+
 void GameSettings::ItemClickCallback(GW::HookStatus *, uint32_t type, uint32_t slot, GW::Bag *bag) {
 	if (!GameSettings::Instance().move_item_on_ctrl_click) return;
-    if (!ImGui::IsKeyDown(VK_CONTROL)) return;
+    if (!(ImGui::IsKeyDown(VK_CONTROL) || ImGui::IsKeyDown(VK_SHIFT))) return;
 	if (type != 7) return;
 
 	// Expected behaviors
@@ -1780,6 +1858,16 @@ void GameSettings::ItemClickCallback(GW::HookStatus *, uint32_t type, uint32_t s
 
 	GW::Item *item = GW::Items::GetItemBySlot(bag, slot + 1);
 	if (!item) return;
+
+	
+	// \x2 means "new section", \x102 means "carriage return/new line", and \x108\x107 means "parse the following code as normal text until you find the next \x1 token"
+	if (ImGui::IsKeyDown(VK_SHIFT)) {
+	    printf("\nitem->model_file_id: %d\n", item->model_file_id);
+
+		WikiSalvageCheck(item);
+	    
+	    return;
+	}
 
 	// @Cleanup: Bad
 	if (item->model_file_id == 0x0002f301) {

--- a/GWToolbox/GWToolbox/Modules/GameSettings.cpp
+++ b/GWToolbox/GWToolbox/Modules/GameSettings.cpp
@@ -1786,7 +1786,7 @@ static void ParseWiki(std::string wiki_page) {
 	wiki_page.erase(std::remove(wiki_page.begin(), wiki_page.end(), '\r'), wiki_page.end());
 	wiki_page.erase(std::remove(wiki_page.begin(), wiki_page.end(), '\t'), wiki_page.end());
 
-	std::cout << wiki_page << std::endl;
+	//std::cout << wiki_page << std::endl;
 
 	std::cout << "wiki_page.length: " << wiki_page.length() << std::endl;
 
@@ -1823,6 +1823,7 @@ static void WikiSalvageCheck(GW::Item *item) {
 	printf("<%ls>\n", chat_url.c_str());
 
 	GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, chat_url.c_str());
+	ShellExecuteW(NULL, L"open", final_url.c_str(), NULL, NULL, SW_SHOWNORMAL);
 	//Resources::Instance().Download(L"https://wiki.guildwars.com/wiki/Pronged_Fan", WikiSalvageCallback);
 	Resources::Instance().Download(final_url, WikiSalvageCallback);
 }

--- a/GWToolbox/GWToolbox/Modules/GameSettings.cpp
+++ b/GWToolbox/GWToolbox/Modules/GameSettings.cpp
@@ -41,9 +41,6 @@
 #include <Color.h>
 #include <Windows\StringDecoderWindow.h>
 
-#include <Modules/Resources.h>
-#include <regex>
-
 namespace {
 	void SendChatCallback(GW::HookStatus *, GW::Chat::Channel chan, wchar_t msg[120]) {
 		if (!GameSettings::Instance().auto_url || !msg) return;
@@ -1752,85 +1749,9 @@ bool GameSettings::WndProc(UINT Message, WPARAM wParam, LPARAM lParam) {
 	return false;
 }
 
-static void ExtractCraftingFromWiki(std::string wiki_page, std::string regex_str) {
-	std::cout << regex_str << std::endl;
-
-	std::smatch sm1;
-	std::regex regex_check1(regex_str);
-
-	// grab the right <td></td>
-	std::regex_search(wiki_page, sm1, regex_check1);
-
-	std::cout << "sm1.length: " << sm1.size() << std::endl;
-
-	for (auto m : sm1) {
-		std::cout << '[' << m << ']' << std::endl;
-	}
-
-	if (sm1.size() == 2) {
-		// TODO: replace <br /> with newline
-
-		// strip all tags
-		std::regex regex_tags("<[^>]*>");
-		std::string final = std::regex_replace(sm1.str(1), regex_tags, "");// "!");
-
-		std::cout << final << std::endl;
-		
-		GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, final.c_str());
-	}
-}
-
-static void ParseWiki(std::string wiki_page) {
-	std::cout << "wiki_page.length: " << wiki_page.length() << std::endl;
-	wiki_page.erase(std::remove(wiki_page.begin(), wiki_page.end(), '\n'), wiki_page.end());
-	wiki_page.erase(std::remove(wiki_page.begin(), wiki_page.end(), '\r'), wiki_page.end());
-	wiki_page.erase(std::remove(wiki_page.begin(), wiki_page.end(), '\t'), wiki_page.end());
-
-	//std::cout << wiki_page << std::endl;
-
-	std::cout << "wiki_page.length: " << wiki_page.length() << std::endl;
-
-	GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, "Common_crafting_material");
-	ExtractCraftingFromWiki(wiki_page, "Common_crafting_material.*?<td>(.*?)</td>");
-
-	GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, "Rare_crafting_material");
-	ExtractCraftingFromWiki(wiki_page, "Rare_crafting_material.*?<td>(.*?)</td>");
-}
-
-static void WikiSalvageCallback(std::string html) {
-
-	//std::string test_str = "asdasd a dADS  \n3 r234wr atr 34ta34 <tr valign=\"top\">\n<th style=\"background-color:#FA5;\"> <span\nstyle=\"white-space:nowrap;\"><a href=\"/wiki/Common_crafting_material\" title=\"Common crafting material\">Common salvage</a></span></th><td> <a href=\"/wiki/Pile_of_Glittering_Dust\" title=\"Pile of Glittering Dust\">Pile of Glittering Dust</a></td></tr><tr valign=\"top\">\n<th style=\"background-color:#FA5;\"> <span\nstyle=\"white-space:nowrap;\"><a href=\"/wiki/Common_crafting_material\" title=\"Common crafting material\">Common salvage</a></span></th><td> <a href=\"/wiki/Pile_of_Glittering_Dust\" title=\"Pile of Glittering Dust\">Pile of Glittering Dust</a></td></tr>";
-	//std::string test_str2 = "<table align=\"right\" style=\"margin:0 0 0.5em 1em; border:1px solid silver; font-size:90%; text-align:left; background-color:white;\" cellpadding=\"5\" cellspacing=\"3\"><tr><th colspan=\"2\" style=\"font-size:110%; text-align:center; background-color:#FA5;\"> Pronged Fan</th></tr><tr><td colspan=\"2\" align=\"center\"> <a href=\"/wiki/File:Pronged_Fan.jpg\" class=\"image\"><img alt=\"Pronged Fan.jpg\" src=\"/images/e/e8/Pronged_Fan.jpg\" width=\"250\" height=\"379\" /></a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <a href=\"/wiki/Weapon#Weapon_types\" title=\"Weapon\">Type</a></th><td> <a href=\"/wiki/Focus_item\" title=\"Focus item\">Focus item</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <a href=\"/wiki/Campaign\" title=\"Campaign\">Campaign(s)</a></th><td> <a href=\"/wiki/Factions\" class=\"mw-redirect\" title=\"Factions\">Factions</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <a href=\"/wiki/Attribute\" title=\"Attribute\">Attribute</a><br /><a href=\"/wiki/Requirement\" title=\"Requirement\">requirement(s)</a></th><td> <a href=\"/wiki/Divine_Favor\" title=\"Divine Favor\">Divine Favor</a><br /><a href=\"/wiki/Energy_Storage\" title=\"Energy Storage\">Energy Storage</a><br /><a href=\"/wiki/Inspiration_Magic\" title=\"Inspiration Magic\">Inspiration Magic</a><br /><a href=\"/wiki/Soul_Reaping\" title=\"Soul Reaping\">Soul Reaping</a><br /><a href=\"/wiki/Spawning_Power\" title=\"Spawning Power\">Spawning Power</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/PvP_reward\" title=\"PvP reward\">PvP reward class</a></span></th><td> Exotic<br />5 <span style=\"position:relative;top:-1.5px\"><a href=\"/wiki/File:Gold_Zaishen_Coin.png\" class=\"image\" title=\"Gold Zaishen Coin\"><img alt=\"Gold Zaishen Coin\" src=\"/images/thumb/2/26/Gold_Zaishen_Coin.png/19px-Gold_Zaishen_Coin.png\" width=\"19\" height=\"19\" srcset=\"/images/thumb/2/26/Gold_Zaishen_Coin.png/29px-Gold_Zaishen_Coin.png 1.5x, /images/thumb/2/26/Gold_Zaishen_Coin.png/38px-Gold_Zaishen_Coin.png 2x\" /></a></span></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/Common_crafting_material\" title=\"Common crafting material\">Common salvage</a></span></th><td> <a href=\"/wiki/Pile_of_Glittering_Dust\" title=\"Pile of Glittering Dust\">Pile of Glittering Dust</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/Rare_crafting_material\" title=\"Rare crafting material\">Rare salvage</a></span></th><td> ~9 <a href=\"/wiki/Roll_of_Parchment\" title=\"Roll of Parchment\">Rolls of Parchment</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/Inventory\" title=\"Inventory\">Inventory icon</a></span></th><td> <a href=\"/wiki/File:Pronged_Fan.png\" class=\"image\"><img alt=\"Pronged Fan.png\" src=\"/images/7/79/Pronged_Fan.png\" width=\"64\" height=\"64\" /></a></td></tr></table><table style=\"margin: 0.5em; border: 1px solid silver;\" cellpadding=\"5\" cellspacing=\"2\"><tr><td style=\"border:1px solid #aaa;\"> <a href=\"/wiki/File:Pronged_Fan_dye_chart.jpg\" class=\"image\"><img alt=\"Pronged Fan dye chart.jpg\" src=\"/images/thumb/9/97/Pronged_Fan_dye_chart.jpg/500px-Pronged_Fan_dye_chart.jpg\" width=\"500\" height=\"339\" srcset=\"/images/thumb/9/97/Pronged_Fan_dye_chart.jpg/750px-Pronged_Fan_dye_chart.jpg 1.5x, /images/9/97/Pronged_Fan_dye_chart.jpg 2x\" /></a></td></tr></table>";
-	//ParseWiki(test_str);
-	//ParseWiki(test_str2);
-	ParseWiki(html);
-
-
-}
-
-static void WikiSalvageCheck(GW::Item *item) {
-	std::wstring decoded;
-	std::wstring wiki_url(L"https://wiki.guildwars.com/wiki/");
-
-	GW::UI::AsyncDecodeStr(item->name_enc, &decoded);
-
-	std::wstring item_url = std::regex_replace(decoded, std::wregex(L" "), std::wstring(L"_"));
-	std::wstring final_url = wiki_url + item_url;
-	std::wstring chat_url = std::wstring(L"<a=1>") + final_url + std::wstring(L"</a>");
-	
-	printf("<%ls>\n", decoded.c_str());
-	printf("<%ls>\n", item_url.c_str());
-	printf("<%ls>\n", chat_url.c_str());
-
-	GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, chat_url.c_str());
-	ShellExecuteW(NULL, L"open", final_url.c_str(), NULL, NULL, SW_SHOWNORMAL);
-	//Resources::Instance().Download(L"https://wiki.guildwars.com/wiki/Pronged_Fan", WikiSalvageCallback);
-	Resources::Instance().Download(final_url, WikiSalvageCallback);
-}
-
 void GameSettings::ItemClickCallback(GW::HookStatus *, uint32_t type, uint32_t slot, GW::Bag *bag) {
 	if (!GameSettings::Instance().move_item_on_ctrl_click) return;
-    if (!(ImGui::IsKeyDown(VK_CONTROL) || ImGui::IsKeyDown(VK_SHIFT))) return;
+    if (!ImGui::IsKeyDown(VK_CONTROL)) return;
 	if (type != 7) return;
 
 	// Expected behaviors
@@ -1859,16 +1780,6 @@ void GameSettings::ItemClickCallback(GW::HookStatus *, uint32_t type, uint32_t s
 
 	GW::Item *item = GW::Items::GetItemBySlot(bag, slot + 1);
 	if (!item) return;
-
-	
-	// \x2 means "new section", \x102 means "carriage return/new line", and \x108\x107 means "parse the following code as normal text until you find the next \x1 token"
-	if (ImGui::IsKeyDown(VK_SHIFT)) {
-	    printf("\nitem->model_file_id: %d\n", item->model_file_id);
-
-		WikiSalvageCheck(item);
-	    
-	    return;
-	}
 
 	// @Cleanup: Bad
 	if (item->model_file_id == 0x0002f301) {
@@ -1952,4 +1863,3 @@ void GameSettings::DrawChannelColor(const char *name, GW::Chat::Channel chan) {
 	}
     ImGui::PopID();
 }
-

--- a/GWToolbox/GWToolbox/Modules/QuickWikiModule.cpp
+++ b/GWToolbox/GWToolbox/Modules/QuickWikiModule.cpp
@@ -1,0 +1,142 @@
+#include "stdafx.h"
+
+#include <GWCA/Managers/ChatMgr.h>
+#include <GWCA/Managers/ItemMgr.h>
+#include <GWCA/Managers/UIMgr.h>
+
+#include "QuickWikiModule.h"
+#include "Modules/Resources.h"
+
+#include "logger.h"
+#include <Timer.h>
+
+namespace {}
+
+void QuickWikiModule::Initialize() {
+	std::cout << "QuickWikiModule::Initialize" << std::endl;
+	ToolboxModule::Initialize();
+	GW::Items::RegisterItemClickCallback(&ItemClickCallback_Entry, QuickWikiModule::ItemClickCallback);
+}
+
+static void ExtractCraftingFromWiki(std::string wiki_page, std::string regex_str) {
+	std::cout << regex_str << std::endl;
+
+	std::smatch sm1;
+	std::regex regex_check1(regex_str);
+
+	// grab the right <td></td>
+	std::regex_search(wiki_page, sm1, regex_check1);
+
+	std::cout << "sm1.length: " << sm1.size() << std::endl;
+
+	for (auto m : sm1) {
+		std::cout << '[' << m << ']' << std::endl;
+	}
+
+	if (sm1.size() == 2) {
+		// TODO: replace <br /> with newline
+
+		// strip all tags
+		std::regex regex_tags("<[^>]*>");
+		std::string final = std::regex_replace(sm1.str(1), regex_tags, "");// "!");
+
+		std::cout << final << std::endl;
+
+		GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, final.c_str());
+	}
+}
+
+static void ParseWiki(std::string wiki_page) {
+	std::cout << "wiki_page.length: " << wiki_page.length() << std::endl;
+	wiki_page.erase(std::remove(wiki_page.begin(), wiki_page.end(), '\n'), wiki_page.end());
+	wiki_page.erase(std::remove(wiki_page.begin(), wiki_page.end(), '\r'), wiki_page.end());
+	wiki_page.erase(std::remove(wiki_page.begin(), wiki_page.end(), '\t'), wiki_page.end());
+
+	//std::cout << wiki_page << std::endl;
+
+	std::cout << "wiki_page.length: " << wiki_page.length() << std::endl;
+
+	GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, "Common_crafting_material");
+	ExtractCraftingFromWiki(wiki_page, "Common_crafting_material.*?<td>(.*?)</td>");
+
+	GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, "Rare_crafting_material");
+	ExtractCraftingFromWiki(wiki_page, "Rare_crafting_material.*?<td>(.*?)</td>");
+}
+
+static void WikiSalvageCallback(std::string html) {
+
+	//std::string test_str = "asdasd a dADS  \n3 r234wr atr 34ta34 <tr valign=\"top\">\n<th style=\"background-color:#FA5;\"> <span\nstyle=\"white-space:nowrap;\"><a href=\"/wiki/Common_crafting_material\" title=\"Common crafting material\">Common salvage</a></span></th><td> <a href=\"/wiki/Pile_of_Glittering_Dust\" title=\"Pile of Glittering Dust\">Pile of Glittering Dust</a></td></tr><tr valign=\"top\">\n<th style=\"background-color:#FA5;\"> <span\nstyle=\"white-space:nowrap;\"><a href=\"/wiki/Common_crafting_material\" title=\"Common crafting material\">Common salvage</a></span></th><td> <a href=\"/wiki/Pile_of_Glittering_Dust\" title=\"Pile of Glittering Dust\">Pile of Glittering Dust</a></td></tr>";
+	//std::string test_str2 = "<table align=\"right\" style=\"margin:0 0 0.5em 1em; border:1px solid silver; font-size:90%; text-align:left; background-color:white;\" cellpadding=\"5\" cellspacing=\"3\"><tr><th colspan=\"2\" style=\"font-size:110%; text-align:center; background-color:#FA5;\"> Pronged Fan</th></tr><tr><td colspan=\"2\" align=\"center\"> <a href=\"/wiki/File:Pronged_Fan.jpg\" class=\"image\"><img alt=\"Pronged Fan.jpg\" src=\"/images/e/e8/Pronged_Fan.jpg\" width=\"250\" height=\"379\" /></a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <a href=\"/wiki/Weapon#Weapon_types\" title=\"Weapon\">Type</a></th><td> <a href=\"/wiki/Focus_item\" title=\"Focus item\">Focus item</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <a href=\"/wiki/Campaign\" title=\"Campaign\">Campaign(s)</a></th><td> <a href=\"/wiki/Factions\" class=\"mw-redirect\" title=\"Factions\">Factions</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <a href=\"/wiki/Attribute\" title=\"Attribute\">Attribute</a><br /><a href=\"/wiki/Requirement\" title=\"Requirement\">requirement(s)</a></th><td> <a href=\"/wiki/Divine_Favor\" title=\"Divine Favor\">Divine Favor</a><br /><a href=\"/wiki/Energy_Storage\" title=\"Energy Storage\">Energy Storage</a><br /><a href=\"/wiki/Inspiration_Magic\" title=\"Inspiration Magic\">Inspiration Magic</a><br /><a href=\"/wiki/Soul_Reaping\" title=\"Soul Reaping\">Soul Reaping</a><br /><a href=\"/wiki/Spawning_Power\" title=\"Spawning Power\">Spawning Power</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/PvP_reward\" title=\"PvP reward\">PvP reward class</a></span></th><td> Exotic<br />5 <span style=\"position:relative;top:-1.5px\"><a href=\"/wiki/File:Gold_Zaishen_Coin.png\" class=\"image\" title=\"Gold Zaishen Coin\"><img alt=\"Gold Zaishen Coin\" src=\"/images/thumb/2/26/Gold_Zaishen_Coin.png/19px-Gold_Zaishen_Coin.png\" width=\"19\" height=\"19\" srcset=\"/images/thumb/2/26/Gold_Zaishen_Coin.png/29px-Gold_Zaishen_Coin.png 1.5x, /images/thumb/2/26/Gold_Zaishen_Coin.png/38px-Gold_Zaishen_Coin.png 2x\" /></a></span></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/Common_crafting_material\" title=\"Common crafting material\">Common salvage</a></span></th><td> <a href=\"/wiki/Pile_of_Glittering_Dust\" title=\"Pile of Glittering Dust\">Pile of Glittering Dust</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/Rare_crafting_material\" title=\"Rare crafting material\">Rare salvage</a></span></th><td> ~9 <a href=\"/wiki/Roll_of_Parchment\" title=\"Roll of Parchment\">Rolls of Parchment</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/Inventory\" title=\"Inventory\">Inventory icon</a></span></th><td> <a href=\"/wiki/File:Pronged_Fan.png\" class=\"image\"><img alt=\"Pronged Fan.png\" src=\"/images/7/79/Pronged_Fan.png\" width=\"64\" height=\"64\" /></a></td></tr></table><table style=\"margin: 0.5em; border: 1px solid silver;\" cellpadding=\"5\" cellspacing=\"2\"><tr><td style=\"border:1px solid #aaa;\"> <a href=\"/wiki/File:Pronged_Fan_dye_chart.jpg\" class=\"image\"><img alt=\"Pronged Fan dye chart.jpg\" src=\"/images/thumb/9/97/Pronged_Fan_dye_chart.jpg/500px-Pronged_Fan_dye_chart.jpg\" width=\"500\" height=\"339\" srcset=\"/images/thumb/9/97/Pronged_Fan_dye_chart.jpg/750px-Pronged_Fan_dye_chart.jpg 1.5x, /images/9/97/Pronged_Fan_dye_chart.jpg 2x\" /></a></td></tr></table>";
+	//ParseWiki(test_str);
+	//ParseWiki(test_str2);
+	ParseWiki(html);
+
+
+}
+
+static void WikiSalvageCheck(GW::Item* item) {
+	std::wstring decoded;
+	std::wstring wiki_url(L"https://wiki.guildwars.com/wiki/");
+
+	GW::UI::AsyncDecodeStr(item->name_enc, &decoded);
+
+	std::wstring item_url = std::regex_replace(decoded, std::wregex(L" "), std::wstring(L"_"));
+	std::wstring final_url = wiki_url + item_url;
+	std::wstring chat_url = std::wstring(L"<a=1>") + final_url + std::wstring(L"</a>");
+
+	printf("<%ls>\n", decoded.c_str());
+	printf("<%ls>\n", item_url.c_str());
+	printf("<%ls>\n", chat_url.c_str());
+
+	GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, chat_url.c_str());
+	ShellExecuteW(NULL, L"open", final_url.c_str(), NULL, NULL, SW_SHOWNORMAL);
+	//Resources::Instance().Download(L"https://wiki.guildwars.com/wiki/Pronged_Fan", WikiSalvageCallback);
+	Resources::Instance().Download(final_url, WikiSalvageCallback);
+}
+
+
+void QuickWikiModule::ItemClickCallback(GW::HookStatus*, uint32_t type, uint32_t slot, GW::Bag* bag) {
+	std::cout << "QuickWikiModule::ItemClickCallback" << std::endl;
+	if (false) return; // todo settings
+	if (!ImGui::IsKeyDown(VK_SHIFT)) return;
+	if (type != 7) return;
+
+	bool is_inventory_item = bag->IsInventoryBag();
+	bool is_storage_item = bag->IsStorageBag();
+	if (!is_inventory_item && !is_storage_item) return;
+
+	GW::Item* item = GW::Items::GetItemBySlot(bag, slot + 1);
+	if (!item) return;
+
+	printf("\nitem->model_file_id: %d\n", item->model_file_id);
+
+	WikiSalvageCheck(item);
+}
+
+
+void QuickWikiModule::SignalTerminate() {
+	std::cout << "QuickWikiModule::SignalTerminate" << std::endl;
+}
+
+void QuickWikiModule::Update(float delta) {
+	//std::cout << "QuickWikiModule::Update" << std::endl;
+}
+
+void QuickWikiModule::LoadSettings(CSimpleIni* ini) {
+	ToolboxModule::LoadSettings(ini);
+	std::cout << "QuickWikiModule::LoadSettings" << std::endl;
+
+	// enabled = ini->GetBoolValue(Name(), VAR_NAME(enabled), enabled);
+}
+
+void QuickWikiModule::SaveSettings(CSimpleIni* ini) {
+	ToolboxModule::SaveSettings(ini);
+	std::cout << "QuickWikiModule::LoadSettings" << std::endl;
+
+	// ini->SetBoolValue(Name(), VAR_NAME(enabled), enabled);
+}
+
+void QuickWikiModule::DrawSettingInternal() {
+	std::cout << "QuickWikiModule::DrawSettingInternal" << std::endl;
+    ImGui::TextDisabled("QuickWikiModule::DrawSettingInternal");
+}

--- a/GWToolbox/GWToolbox/Modules/QuickWikiModule.cpp
+++ b/GWToolbox/GWToolbox/Modules/QuickWikiModule.cpp
@@ -10,95 +10,110 @@
 #include "logger.h"
 #include <Timer.h>
 
-namespace {}
+#define TEST_STR  "asdasd a dADS  \n3 r234wr atr 34ta34 <tr valign=\"top\">\n<th style=\"background-color:#FA5;\"> <span\nstyle=\"white-space:nowrap;\"><a href=\"/wiki/Common_crafting_material\" title=\"Common crafting material\">Common salvage</a></span></th><td> <a href=\"/wiki/Pile_of_Glittering_Dust\" title=\"Pile of Glittering Dust\">Pile of Glittering Dust</a></td></tr><tr valign=\"top\">\n<th style=\"background-color:#FA5;\"> <span\nstyle=\"white-space:nowrap;\"><a href=\"/wiki/Common_crafting_material\" title=\"Common crafting material\">Common salvage</a></span></th><td> <a href=\"/wiki/Pile_of_Glittering_Dust\" title=\"Pile of Glittering Dust\">Pile of Glittering Dust</a></td></tr>";
+#define TEST_STR2 "<table align=\"right\" style=\"margin:0 0 0.5em 1em; border:1px solid silver; font-size:90%; text-align:left; background-color:white;\" cellpadding=\"5\" cellspacing=\"3\"><tr><th colspan=\"2\" style=\"font-size:110%; text-align:center; background-color:#FA5;\"> Pronged Fan</th></tr><tr><td colspan=\"2\" align=\"center\"> <a href=\"/wiki/File:Pronged_Fan.jpg\" class=\"image\"><img alt=\"Pronged Fan.jpg\" src=\"/images/e/e8/Pronged_Fan.jpg\" width=\"250\" height=\"379\" /></a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <a href=\"/wiki/Weapon#Weapon_types\" title=\"Weapon\">Type</a></th><td> <a href=\"/wiki/Focus_item\" title=\"Focus item\">Focus item</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <a href=\"/wiki/Campaign\" title=\"Campaign\">Campaign(s)</a></th><td> <a href=\"/wiki/Factions\" class=\"mw-redirect\" title=\"Factions\">Factions</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <a href=\"/wiki/Attribute\" title=\"Attribute\">Attribute</a><br /><a href=\"/wiki/Requirement\" title=\"Requirement\">requirement(s)</a></th><td> <a href=\"/wiki/Divine_Favor\" title=\"Divine Favor\">Divine Favor</a><br /><a href=\"/wiki/Energy_Storage\" title=\"Energy Storage\">Energy Storage</a><br /><a href=\"/wiki/Inspiration_Magic\" title=\"Inspiration Magic\">Inspiration Magic</a><br /><a href=\"/wiki/Soul_Reaping\" title=\"Soul Reaping\">Soul Reaping</a><br /><a href=\"/wiki/Spawning_Power\" title=\"Spawning Power\">Spawning Power</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/PvP_reward\" title=\"PvP reward\">PvP reward class</a></span></th><td> Exotic<br />5 <span style=\"position:relative;top:-1.5px\"><a href=\"/wiki/File:Gold_Zaishen_Coin.png\" class=\"image\" title=\"Gold Zaishen Coin\"><img alt=\"Gold Zaishen Coin\" src=\"/images/thumb/2/26/Gold_Zaishen_Coin.png/19px-Gold_Zaishen_Coin.png\" width=\"19\" height=\"19\" srcset=\"/images/thumb/2/26/Gold_Zaishen_Coin.png/29px-Gold_Zaishen_Coin.png 1.5x, /images/thumb/2/26/Gold_Zaishen_Coin.png/38px-Gold_Zaishen_Coin.png 2x\" /></a></span></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/Common_crafting_material\" title=\"Common crafting material\">Common salvage</a></span></th><td> <a href=\"/wiki/Pile_of_Glittering_Dust\" title=\"Pile of Glittering Dust\">Pile of Glittering Dust</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/Rare_crafting_material\" title=\"Rare crafting material\">Rare salvage</a></span></th><td> ~9 <a href=\"/wiki/Roll_of_Parchment\" title=\"Roll of Parchment\">Rolls of Parchment</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/Inventory\" title=\"Inventory\">Inventory icon</a></span></th><td> <a href=\"/wiki/File:Pronged_Fan.png\" class=\"image\"><img alt=\"Pronged Fan.png\" src=\"/images/7/79/Pronged_Fan.png\" width=\"64\" height=\"64\" /></a></td></tr></table><table style=\"margin: 0.5em; border: 1px solid silver;\" cellpadding=\"5\" cellspacing=\"2\"><tr><td style=\"border:1px solid #aaa;\"> <a href=\"/wiki/File:Pronged_Fan_dye_chart.jpg\" class=\"image\"><img alt=\"Pronged Fan dye chart.jpg\" src=\"/images/thumb/9/97/Pronged_Fan_dye_chart.jpg/500px-Pronged_Fan_dye_chart.jpg\" width=\"500\" height=\"339\" srcset=\"/images/thumb/9/97/Pronged_Fan_dye_chart.jpg/750px-Pronged_Fan_dye_chart.jpg 1.5x, /images/9/97/Pronged_Fan_dye_chart.jpg 2x\" /></a></td></tr></table>";
+	
+const std::wstring wiki_url(L"https://wiki.guildwars.com/wiki/");
 
 void QuickWikiModule::Initialize() {
-	std::cout << "QuickWikiModule::Initialize" << std::endl;
+	//std::cout << "QuickWikiModule::Initialize" << std::endl;
 	ToolboxModule::Initialize();
 	GW::Items::RegisterItemClickCallback(&ItemClickCallback_Entry, QuickWikiModule::ItemClickCallback);
 }
 
-static void ExtractCraftingFromWiki(std::string wiki_page, std::string regex_str) {
-	std::cout << regex_str << std::endl;
+inline static std::wstring BuildWikiLink(std::wstring &item_url) {
+	return wiki_url + item_url;
+}
 
+inline static std::wstring BuildChatLink(std::wstring& url) {
+	return std::wstring(L"<a=1>") + url + std::wstring(L"</a>");
+}
+
+static std::wstring DecodeToWikiLink(wchar_t *inp) {
+	std::wstring decoded;
+	GW::UI::AsyncDecodeStr(inp, &decoded);
+	std::wstring item_url = std::regex_replace(decoded, std::wregex(L" "), std::wstring(L"_"));
+#ifdef _DEBUG
+	printf("<%ls>\n", decoded.c_str());
+	printf("<%ls>\n", item_url.c_str());
+#endif
+	return BuildWikiLink(item_url);
+	//std::wstring chat_url = BuildChatLink(final_url);
+
+}
+
+
+static void ExtractMaterialFromWiki(std::string wiki_page, std::string regex_str) {
 	std::smatch sm1;
-	std::regex regex_check1(regex_str);
+	std::regex_search(wiki_page, sm1, std::regex(regex_str));
 
-	// grab the right <td></td>
-	std::regex_search(wiki_page, sm1, regex_check1);
-
+#if _DEBUG
+	std::cout << regex_str << std::endl;
 	std::cout << "sm1.length: " << sm1.size() << std::endl;
-
 	for (auto m : sm1) {
 		std::cout << '[' << m << ']' << std::endl;
 	}
-
+#endif
+	// sm1 should contain two items if we found a proper table entry.
 	if (sm1.size() == 2) {
-		// TODO: replace <br /> with newline
+		// replace <br /> with separator
+		std::string final = std::regex_replace(sm1.str(1), std::regex("<br[^>]*>"), ";");
 
-		// strip all tags
-		std::regex regex_tags("<[^>]*>");
-		std::string final = std::regex_replace(sm1.str(1), regex_tags, "");// "!");
+		// strip all tags (usually links)
+		final = std::regex_replace(final, std::regex("<[^>]*>"), "");
 
+#if _DEBUG
 		std::cout << final << std::endl;
+#endif
 
 		GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, final.c_str());
 	}
 }
 
-static void ParseWiki(std::string wiki_page) {
+static void WikiParseSalvage(std::string wiki_page) {
+#if _DEBUG
 	std::cout << "wiki_page.length: " << wiki_page.length() << std::endl;
-	wiki_page.erase(std::remove(wiki_page.begin(), wiki_page.end(), '\n'), wiki_page.end());
-	wiki_page.erase(std::remove(wiki_page.begin(), wiki_page.end(), '\r'), wiki_page.end());
-	wiki_page.erase(std::remove(wiki_page.begin(), wiki_page.end(), '\t'), wiki_page.end());
-
-	//std::cout << wiki_page << std::endl;
-
+#endif
+	wiki_page.erase(std::remove_if(wiki_page.begin(), wiki_page.end(), 
+		[](char c) {return c < 0x20 or c > 0x7e;}
+		), wiki_page.end());
+#if _DEBUG
 	std::cout << "wiki_page.length: " << wiki_page.length() << std::endl;
+#endif
 
-	GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, "Common_crafting_material");
-	ExtractCraftingFromWiki(wiki_page, "Common_crafting_material.*?<td>(.*?)</td>");
+	// Check if this in the string, the regex is slow if it's not.
+	if (wiki_page.find("Common_crafting_material") != std::string::npos) {
+		GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, "Common_crafting_material");
+		// The information is in a <td> entry, with a header containing a link to wiki/Common_crafting_material.
+		// On salvagable material pages, there will be multiple material links. The table we are looking for is
+		// right aligned with align="right" or "float:right"
+		ExtractMaterialFromWiki(wiki_page, "<th.*?Common_crafting_material.*?</th>.*?<td>(.*?)</td>");
+	}
 
-	GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, "Rare_crafting_material");
-	ExtractCraftingFromWiki(wiki_page, "Rare_crafting_material.*?<td>(.*?)</td>");
+	if (wiki_page.find("Rare_crafting_material") != std::string::npos) {
+		GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, "Rare_crafting_material");
+		ExtractMaterialFromWiki(wiki_page, "<th.*?Rare_crafting_material.*?</th>.*?<td>(.*?)</td>");
+	}
 }
 
-static void WikiSalvageCallback(std::string html) {
-
-	//std::string test_str = "asdasd a dADS  \n3 r234wr atr 34ta34 <tr valign=\"top\">\n<th style=\"background-color:#FA5;\"> <span\nstyle=\"white-space:nowrap;\"><a href=\"/wiki/Common_crafting_material\" title=\"Common crafting material\">Common salvage</a></span></th><td> <a href=\"/wiki/Pile_of_Glittering_Dust\" title=\"Pile of Glittering Dust\">Pile of Glittering Dust</a></td></tr><tr valign=\"top\">\n<th style=\"background-color:#FA5;\"> <span\nstyle=\"white-space:nowrap;\"><a href=\"/wiki/Common_crafting_material\" title=\"Common crafting material\">Common salvage</a></span></th><td> <a href=\"/wiki/Pile_of_Glittering_Dust\" title=\"Pile of Glittering Dust\">Pile of Glittering Dust</a></td></tr>";
-	//std::string test_str2 = "<table align=\"right\" style=\"margin:0 0 0.5em 1em; border:1px solid silver; font-size:90%; text-align:left; background-color:white;\" cellpadding=\"5\" cellspacing=\"3\"><tr><th colspan=\"2\" style=\"font-size:110%; text-align:center; background-color:#FA5;\"> Pronged Fan</th></tr><tr><td colspan=\"2\" align=\"center\"> <a href=\"/wiki/File:Pronged_Fan.jpg\" class=\"image\"><img alt=\"Pronged Fan.jpg\" src=\"/images/e/e8/Pronged_Fan.jpg\" width=\"250\" height=\"379\" /></a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <a href=\"/wiki/Weapon#Weapon_types\" title=\"Weapon\">Type</a></th><td> <a href=\"/wiki/Focus_item\" title=\"Focus item\">Focus item</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <a href=\"/wiki/Campaign\" title=\"Campaign\">Campaign(s)</a></th><td> <a href=\"/wiki/Factions\" class=\"mw-redirect\" title=\"Factions\">Factions</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <a href=\"/wiki/Attribute\" title=\"Attribute\">Attribute</a><br /><a href=\"/wiki/Requirement\" title=\"Requirement\">requirement(s)</a></th><td> <a href=\"/wiki/Divine_Favor\" title=\"Divine Favor\">Divine Favor</a><br /><a href=\"/wiki/Energy_Storage\" title=\"Energy Storage\">Energy Storage</a><br /><a href=\"/wiki/Inspiration_Magic\" title=\"Inspiration Magic\">Inspiration Magic</a><br /><a href=\"/wiki/Soul_Reaping\" title=\"Soul Reaping\">Soul Reaping</a><br /><a href=\"/wiki/Spawning_Power\" title=\"Spawning Power\">Spawning Power</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/PvP_reward\" title=\"PvP reward\">PvP reward class</a></span></th><td> Exotic<br />5 <span style=\"position:relative;top:-1.5px\"><a href=\"/wiki/File:Gold_Zaishen_Coin.png\" class=\"image\" title=\"Gold Zaishen Coin\"><img alt=\"Gold Zaishen Coin\" src=\"/images/thumb/2/26/Gold_Zaishen_Coin.png/19px-Gold_Zaishen_Coin.png\" width=\"19\" height=\"19\" srcset=\"/images/thumb/2/26/Gold_Zaishen_Coin.png/29px-Gold_Zaishen_Coin.png 1.5x, /images/thumb/2/26/Gold_Zaishen_Coin.png/38px-Gold_Zaishen_Coin.png 2x\" /></a></span></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/Common_crafting_material\" title=\"Common crafting material\">Common salvage</a></span></th><td> <a href=\"/wiki/Pile_of_Glittering_Dust\" title=\"Pile of Glittering Dust\">Pile of Glittering Dust</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/Rare_crafting_material\" title=\"Rare crafting material\">Rare salvage</a></span></th><td> ~9 <a href=\"/wiki/Roll_of_Parchment\" title=\"Roll of Parchment\">Rolls of Parchment</a></td></tr><tr valign=\"top\"><th style=\"background-color:#FA5;\"> <span style=\"white-space:nowrap;\"><a href=\"/wiki/Inventory\" title=\"Inventory\">Inventory icon</a></span></th><td> <a href=\"/wiki/File:Pronged_Fan.png\" class=\"image\"><img alt=\"Pronged Fan.png\" src=\"/images/7/79/Pronged_Fan.png\" width=\"64\" height=\"64\" /></a></td></tr></table><table style=\"margin: 0.5em; border: 1px solid silver;\" cellpadding=\"5\" cellspacing=\"2\"><tr><td style=\"border:1px solid #aaa;\"> <a href=\"/wiki/File:Pronged_Fan_dye_chart.jpg\" class=\"image\"><img alt=\"Pronged Fan dye chart.jpg\" src=\"/images/thumb/9/97/Pronged_Fan_dye_chart.jpg/500px-Pronged_Fan_dye_chart.jpg\" width=\"500\" height=\"339\" srcset=\"/images/thumb/9/97/Pronged_Fan_dye_chart.jpg/750px-Pronged_Fan_dye_chart.jpg 1.5x, /images/9/97/Pronged_Fan_dye_chart.jpg 2x\" /></a></td></tr></table>";
-	//ParseWiki(test_str);
-	//ParseWiki(test_str2);
-	ParseWiki(html);
-
-
+static void WikiSalvageCheckCallback(std::string html) {
+	WikiParseSalvage(html);
 }
 
-static void WikiSalvageCheck(GW::Item* item) {
-	std::wstring decoded;
-	std::wstring wiki_url(L"https://wiki.guildwars.com/wiki/");
-
-	GW::UI::AsyncDecodeStr(item->name_enc, &decoded);
-
-	std::wstring item_url = std::regex_replace(decoded, std::wregex(L" "), std::wstring(L"_"));
-	std::wstring final_url = wiki_url + item_url;
-	std::wstring chat_url = std::wstring(L"<a=1>") + final_url + std::wstring(L"</a>");
-
-	printf("<%ls>\n", decoded.c_str());
-	printf("<%ls>\n", item_url.c_str());
-	printf("<%ls>\n", chat_url.c_str());
-
-	GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, chat_url.c_str());
-	ShellExecuteW(NULL, L"open", final_url.c_str(), NULL, NULL, SW_SHOWNORMAL);
-	//Resources::Instance().Download(L"https://wiki.guildwars.com/wiki/Pronged_Fan", WikiSalvageCallback);
-	Resources::Instance().Download(final_url, WikiSalvageCallback);
+static void WikiSalvageCheck(std::wstring wiki_url) {
+	Resources::Instance().Download(wiki_url, WikiSalvageCheckCallback);
 }
 
+static void WikiItemOpen(std::wstring wiki_url) {
+	ShellExecuteW(NULL, L"open", wiki_url.c_str(), NULL, NULL, SW_SHOWNORMAL);
+}
 
 void QuickWikiModule::ItemClickCallback(GW::HookStatus*, uint32_t type, uint32_t slot, GW::Bag* bag) {
 	std::cout << "QuickWikiModule::ItemClickCallback" << std::endl;
-	if (false) return; // todo settings
 	if (!ImGui::IsKeyDown(VK_SHIFT)) return;
+	if (!(QuickWikiModule::Instance().shift_click_show_wiki_url or
+		  QuickWikiModule::Instance().shift_click_item_open_wiki or 
+		  QuickWikiModule::Instance().shift_click_parse_wiki_salvage)) return;
 	if (type != 7) return;
 
 	bool is_inventory_item = bag->IsInventoryBag();
@@ -107,15 +122,28 @@ void QuickWikiModule::ItemClickCallback(GW::HookStatus*, uint32_t type, uint32_t
 
 	GW::Item* item = GW::Items::GetItemBySlot(bag, slot + 1);
 	if (!item) return;
-
+#ifdef _DEBUG
 	printf("\nitem->model_file_id: %d\n", item->model_file_id);
+#endif
 
-	WikiSalvageCheck(item);
+	std::wstring wiki_url = DecodeToWikiLink(item->name_enc);
+
+	if (QuickWikiModule::Instance().shift_click_show_wiki_url)
+		GW::Chat::WriteChat(GW::Chat::Channel::CHANNEL_GLOBAL, BuildChatLink(wiki_url).c_str());
+
+	if (QuickWikiModule::Instance().shift_click_item_open_wiki)
+		WikiItemOpen(wiki_url);
+
+	if (QuickWikiModule::Instance().shift_click_parse_wiki_salvage and item->is_material_salvageable)
+		WikiSalvageCheck(wiki_url);
 }
 
-
 void QuickWikiModule::SignalTerminate() {
-	std::cout << "QuickWikiModule::SignalTerminate" << std::endl;
+	//std::cout << "QuickWikiModule::SignalTerminate" << std::endl;
+}
+
+void QuickWikiModule::Terminate() {
+	GW::Items::RemoveItemClickCallback(&ItemClickCallback_Entry);
 }
 
 void QuickWikiModule::Update(float delta) {
@@ -124,19 +152,24 @@ void QuickWikiModule::Update(float delta) {
 
 void QuickWikiModule::LoadSettings(CSimpleIni* ini) {
 	ToolboxModule::LoadSettings(ini);
-	std::cout << "QuickWikiModule::LoadSettings" << std::endl;
 
-	// enabled = ini->GetBoolValue(Name(), VAR_NAME(enabled), enabled);
+	shift_click_show_wiki_url = ini->GetBoolValue(Name(), VAR_NAME(shift_click_show_wiki_url), shift_click_show_wiki_url);
+	shift_click_item_open_wiki = ini->GetBoolValue(Name(), VAR_NAME(shift_click_item_open_wiki), shift_click_item_open_wiki);
+	shift_click_parse_wiki_salvage = ini->GetBoolValue(Name(), VAR_NAME(shift_click_parse_wiki_salvage), shift_click_parse_wiki_salvage);
 }
 
 void QuickWikiModule::SaveSettings(CSimpleIni* ini) {
 	ToolboxModule::SaveSettings(ini);
-	std::cout << "QuickWikiModule::LoadSettings" << std::endl;
 
-	// ini->SetBoolValue(Name(), VAR_NAME(enabled), enabled);
+	ini->SetBoolValue(Name(), VAR_NAME(shift_click_show_wiki_url), shift_click_show_wiki_url);
+	ini->SetBoolValue(Name(), VAR_NAME(shift_click_item_open_wiki), shift_click_item_open_wiki);
+	ini->SetBoolValue(Name(), VAR_NAME(shift_click_parse_wiki_salvage), shift_click_parse_wiki_salvage);
 }
 
 void QuickWikiModule::DrawSettingInternal() {
-	std::cout << "QuickWikiModule::DrawSettingInternal" << std::endl;
-    ImGui::TextDisabled("QuickWikiModule::DrawSettingInternal");
+    ImGui::Text("Shift + Click item");
+	ImGui::Indent();
+	ImGui::Checkbox("shows (potential) wiki url", &shift_click_show_wiki_url);
+	ImGui::Checkbox("opens (potential) wiki page", &shift_click_item_open_wiki);
+	ImGui::Checkbox("attemps to read salvage info from wiki (EXPERIMENTAL)", &shift_click_parse_wiki_salvage);
 }

--- a/GWToolbox/GWToolbox/Modules/QuickWikiModule.cpp
+++ b/GWToolbox/GWToolbox/Modules/QuickWikiModule.cpp
@@ -16,7 +16,6 @@
 const std::wstring wiki_url(L"https://wiki.guildwars.com/wiki/");
 
 void QuickWikiModule::Initialize() {
-	//std::cout << "QuickWikiModule::Initialize" << std::endl;
 	ToolboxModule::Initialize();
 	GW::Items::RegisterItemClickCallback(&ItemClickCallback_Entry, QuickWikiModule::ItemClickCallback);
 }
@@ -38,8 +37,6 @@ static std::wstring DecodeToWikiLink(wchar_t *inp) {
 	printf("<%ls>\n", item_url.c_str());
 #endif
 	return BuildWikiLink(item_url);
-	//std::wstring chat_url = BuildChatLink(final_url);
-
 }
 
 
@@ -172,4 +169,5 @@ void QuickWikiModule::DrawSettingInternal() {
 	ImGui::Checkbox("shows (potential) wiki url", &shift_click_show_wiki_url);
 	ImGui::Checkbox("opens (potential) wiki page", &shift_click_item_open_wiki);
 	ImGui::Checkbox("attemps to read salvage info from wiki (EXPERIMENTAL)", &shift_click_parse_wiki_salvage);
+	ImGui::Unindent();
 }

--- a/GWToolbox/GWToolbox/Modules/QuickWikiModule.h
+++ b/GWToolbox/GWToolbox/Modules/QuickWikiModule.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <imgui.h>
+#include <d3d9.h>
+#include <SimpleIni.h>
+
+#include <GWCA/GameEntities/Item.h>
+#include <ToolboxModule.h>
+#include <ToolboxUIElement.h>
+
+class QuickWikiModule : public ToolboxModule {
+public:
+	QuickWikiModule() {}
+	~QuickWikiModule() {};
+
+public:
+	static QuickWikiModule& Instance() {
+		static QuickWikiModule instance;
+		return instance;
+	}
+
+	const char* Name() const override { return "Quick Wiki"; }
+	
+	void Initialize() override;
+	void SignalTerminate() override;
+	void Update(float delta) override;
+	void DrawSettingInternal() override;
+
+	bool CanTerminate() { return true; };
+	bool HasSettings() { return true; };
+
+	// virtual void DrawHelp() {};
+	// virtual void Terminate() {};
+	// virtual bool WndProc(UINT Message, WPARAM wParam, LPARAM lParam) { return false; };
+
+	void LoadSettings(CSimpleIni* ini);
+	void SaveSettings(CSimpleIni* ini);
+
+	static void ItemClickCallback(GW::HookStatus*, uint32_t type, uint32_t slot, GW::Bag* bag);
+
+private:
+	GW::HookEntry ItemClickCallback_Entry;
+};

--- a/GWToolbox/GWToolbox/Modules/QuickWikiModule.h
+++ b/GWToolbox/GWToolbox/Modules/QuickWikiModule.h
@@ -25,12 +25,12 @@ public:
 	void SignalTerminate() override;
 	void Update(float delta) override;
 	void DrawSettingInternal() override;
+	virtual void Terminate() override;
 
 	bool CanTerminate() { return true; };
 	bool HasSettings() { return true; };
 
 	// virtual void DrawHelp() {};
-	// virtual void Terminate() {};
 	// virtual bool WndProc(UINT Message, WPARAM wParam, LPARAM lParam) { return false; };
 
 	void LoadSettings(CSimpleIni* ini);
@@ -38,6 +38,12 @@ public:
 
 	static void ItemClickCallback(GW::HookStatus*, uint32_t type, uint32_t slot, GW::Bag* bag);
 
+	static const std::wstring wiki_url;
+
 private:
+	bool shift_click_show_wiki_url = true;
+	bool shift_click_item_open_wiki = true;
+	bool shift_click_parse_wiki_salvage = false;
+
 	GW::HookEntry ItemClickCallback_Entry;
 };

--- a/GWToolbox/GWToolbox/Modules/ToolboxSettings.cpp
+++ b/GWToolbox/GWToolbox/Modules/ToolboxSettings.cpp
@@ -68,7 +68,7 @@ bool ToolboxSettings::move_all = false;
 void ToolboxSettings::LoadModules(CSimpleIni* ini) {
 	SettingsWindow::Instance().sep_modules = optional_modules.size();
     optional_modules.push_back(&ZrawDeepModule::Instance());
-    optional_modules.push_back(&QuickWikiModule::Instance());
+    if (use_quick_wiki) optional_modules.push_back(&QuickWikiModule::Instance());
 	if (use_gamesettings) optional_modules.push_back(&GameSettings::Instance());
 	if (use_updater) optional_modules.push_back(&Updater::Instance());
 	if (use_chatfilter) optional_modules.push_back(&ChatFilter::Instance());
@@ -166,6 +166,8 @@ void ToolboxSettings::DrawSettingInternal() {
 	ImGui::SameLine(ImGui::GetWindowWidth() / 2);
 	ImGui::Checkbox("Friend List", &use_friendlist);
 	ImGui::Checkbox("Daily Quests", &use_daily_quests);
+	ImGui::SameLine(ImGui::GetWindowWidth() / 2);
+	ImGui::Checkbox("Quick Wiki", &use_quick_wiki);
 
 	ImGui::PopID();
 
@@ -229,6 +231,7 @@ void ToolboxSettings::LoadSettings(CSimpleIni* ini) {
 	use_friendlist = ini->GetBoolValue(Name(), VAR_NAME(use_friendlist), use_friendlist);
 	use_serverinfo = ini->GetBoolValue(Name(), VAR_NAME(use_serverinfo), use_serverinfo);
 	use_daily_quests = ini->GetBoolValue(Name(), VAR_NAME(use_daily_quests), use_daily_quests);
+	use_quick_wiki = ini->GetBoolValue(Name(), VAR_NAME(use_quick_wiki), use_quick_wiki);
 }
 
 void ToolboxSettings::SaveSettings(CSimpleIni* ini) {
@@ -266,6 +269,7 @@ void ToolboxSettings::SaveSettings(CSimpleIni* ini) {
 	ini->SetBoolValue(Name(), VAR_NAME(use_chatfilter), use_chatfilter);
 	ini->SetBoolValue(Name(), VAR_NAME(use_chatcommand), use_chatcommand);
 	ini->SetBoolValue(Name(), VAR_NAME(use_daily_quests), use_daily_quests);
+	ini->SetBoolValue(Name(), VAR_NAME(use_quick_wiki), use_quick_wiki);
 }
 
 void ToolboxSettings::Update(float delta) {

--- a/GWToolbox/GWToolbox/Modules/ToolboxSettings.cpp
+++ b/GWToolbox/GWToolbox/Modules/ToolboxSettings.cpp
@@ -25,6 +25,7 @@
 #include <Modules/TwitchModule.h>
 #include <Modules/PartyWindowModule.h>
 #include <Modules/ZrawDeepModule.h>
+#include <Modules/QuickWikiModule.h>
 
 #include <Windows/MainWindow.h>
 #include <Windows/PconsWindow.h>
@@ -67,6 +68,7 @@ bool ToolboxSettings::move_all = false;
 void ToolboxSettings::LoadModules(CSimpleIni* ini) {
 	SettingsWindow::Instance().sep_modules = optional_modules.size();
     optional_modules.push_back(&ZrawDeepModule::Instance());
+    optional_modules.push_back(&QuickWikiModule::Instance());
 	if (use_gamesettings) optional_modules.push_back(&GameSettings::Instance());
 	if (use_updater) optional_modules.push_back(&Updater::Instance());
 	if (use_chatfilter) optional_modules.push_back(&ChatFilter::Instance());

--- a/GWToolbox/GWToolbox/Modules/ToolboxSettings.h
+++ b/GWToolbox/GWToolbox/Modules/ToolboxSettings.h
@@ -71,4 +71,5 @@ private:
 	bool use_chatfilter = true;
 	bool use_chatcommand = true;
 	bool use_discordintegration = false;
+	bool use_quick_wiki = true;
 };


### PR DESCRIPTION
If enabled, shift+click on an item by default:
- shows an url in chat box
- tries to open that url

I've also added some regexes to extract common and rare crafting materials from the page, that's by default disabled. The output still misses some pretty printing.