### PR TITLE
Removed SetWindowTitle()'s side-effect when enabled=false

### DIFF
--- a/GWToolbox/GWToolbox/Modules/GameSettings.cpp
+++ b/GWToolbox/GWToolbox/Modules/GameSettings.cpp
@@ -156,11 +156,11 @@ namespace {
 	void SetWindowTitle(bool enabled) {
 		HWND hwnd = GW::MemoryMgr::GetGWWindowHandle();
 		if (!hwnd) return;
-		std::wstring title = L"Guild Wars";
-		if (enabled)
-			title = GetPlayerName();
-		if (!title.empty())
-			SetWindowTextW(hwnd, title.c_str());
+		if (enabled) {
+			std::wstring title = GetPlayerName();
+			if (!title.empty())
+				SetWindowTextW(hwnd, title.c_str());
+		}
 	}
 
 	GW::Player* GetPlayerByName(const wchar_t* _name) {


### PR DESCRIPTION
Changed SetWindowTitle() to no longer modify the window title of the Guild Wars window when enabled=false. Previously it would force the window title to "Guild Wars" which would override any modification made by other programs.

Recommending that this function do nothing when the Toolbox option is disabled. This is the expected behavior.